### PR TITLE
Fix memory leak and ConcurrentModificationException in PdfiumCore.close()

### DIFF
--- a/libPdfium/src/main/java/com/ahmer/pdfium/PdfiumCore.kt
+++ b/libPdfium/src/main/java/com/ahmer/pdfium/PdfiumCore.kt
@@ -495,17 +495,10 @@ class PdfiumCore(
 
     override fun close() {
         Log.v(TAG, "Closing PdfDocument")
-        doc.pageCache.keys.forEach { index ->
-            doc.pageCache[index]?.let { page ->
-                if (page.count > 1) {
-                    page.count--
-                    return
-                }
-                doc.pageCache.remove(key = index)
-                doc.pageCache[index]?.let {
-                    nativeClosePage(pagePtr = it.pagePtr)
-                }
-            }
+        // Close all native page handles - when closing the document entirely,
+        // we must free all native resources regardless of reference count
+        for (entry in doc.pageCache.values) {
+            nativeClosePage(pagePtr = entry.pagePtr)
         }
         doc.close()
     }


### PR DESCRIPTION
## Summary
- Fix native memory leak where pages were never actually closed
- Fix ConcurrentModificationException when closing documents
- Fix non-local return that caused close() to exit prematurely

## Problem

The `close()` method in `PdfiumCore` has three bugs introduced in commit 4b6f2be ("Reverts the coroutine"):

### 1. Native memory leak
```kotlin
doc.pageCache.remove(key = index)
doc.pageCache[index]?.let {  // Always null after remove!
    nativeClosePage(pagePtr = it.pagePtr)
}
```
The lookup happens after removal, so it always returns null and `nativeClosePage()` is never called.

### 2. ConcurrentModificationException
```kotlin
doc.pageCache.keys.forEach { index ->
    doc.pageCache.remove(key = index)  // CME!
}
```
Using `forEach` with `map.remove()` throws CME because forEach uses an iterator internally.

### 3. Non-local return
```kotlin
if (page.count > 1) {
    page.count--
    return  // Exits close() entirely!
}
```
The `return` inside the forEach lambda exits the entire `close()` function, not just the lambda.

## Solution

When closing the entire document, all native page handles must be freed regardless of reference count. The reference counting is meant for individual page management while the document is open (see `PdfTextPage.close()`), not for document destruction.

The fix simply iterates over all cached pages and closes them unconditionally before calling `doc.close()`. This matches the original behavior from commit 44f62b0 before the coroutine refactoring.

## Test Plan
- Verified fix resolves memory leak when repeatedly opening/closing PDFs
- Verified no ConcurrentModificationException when closing documents with multiple pages open